### PR TITLE
Address some race conditions and fix warnings during ExecuteToExecuteWhenFinished, more consistent log message formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,6 @@
-
 Assemblies/
-
 *.pdb
-
 Source/obj/
-
-Source/\.idea/
-
+Source/.idea/
+Source/.vs/
 Source/packages/

--- a/Source/BetterLoading.sln
+++ b/Source/BetterLoading.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30011.22
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BetterLoading", "BetterLoading.csproj", "{E08CFC22-1BA8-41FE-A60B-491C308B8B65}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E08CFC22-1BA8-41FE-A60B-491C308B8B65}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E08CFC22-1BA8-41FE-A60B-491C308B8B65}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E08CFC22-1BA8-41FE-A60B-491C308B8B65}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E08CFC22-1BA8-41FE-A60B-491C308B8B65}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C101E37B-B25A-4E29-AA38-A85832A83342}
+	EndGlobalSection
+EndGlobal

--- a/Source/BetterLoadingMain.cs
+++ b/Source/BetterLoadingMain.cs
@@ -69,7 +69,7 @@ namespace BetterLoading
                         .ToList();
 
                     Log.Error($"[BetterLoading] {dllsThatShouldBeLoaded.Count - dllsActuallyLoaded.Count} assemblies for {pack.Name} failed to load! The ones that didn't load are: {didntLoad.ToCommaList()}");
-                    Log.Error($"[BL] Got {failures.Count} messages that identify those failures.");
+                    Log.Error($"[BetterLoading] Got {failures.Count} messages that identify those failures.");
 
                     DllPathsThatFailedToLoad[pack] = failures;
                 }
@@ -227,7 +227,7 @@ The assemblies that failed to load are:
             catch (Exception)
             {
                 //We really don't want this to fail, it's just gonna be a pain
-                Log.Warning("[BetterLoading] Failed to scrape Loader Errors");
+                Log.Warning("[BetterLoading] Failed to scrape Loader Errors.");
                 return new List<(string type, string asm)>();
             }
         }

--- a/Source/Compat/HugsLib/StageHugsLibInit.cs
+++ b/Source/Compat/HugsLib/StageHugsLibInit.cs
@@ -90,7 +90,7 @@ namespace BetterLoading.Compat.HugsLib
 
             _modIdentifierProperty = hlAssembly.GetTypes().First(t => t.Name == "ModBase").GetProperty("ModIdentifier");
 
-            Log.Message($"[BetterLoading:HugsLib Compat] Resolved required hugslib types as follows: Controller: {controllerType?.FullName} / Update Manager: {updateFeatureManagerType?.FullName} / Mod Identifier (Property): {_modIdentifierProperty?.Name}");
+            Log.Message($"[BetterLoading:HugsLib Compat] Resolved required HugsLib types as follows: Controller: {controllerType?.FullName} / Update Manager: {updateFeatureManagerType?.FullName} / Mod Identifier (Property): {_modIdentifierProperty?.Name}");
 
             hInstance.Patch(AccessTools.Method(controllerType, "LoadReloadInitialize"), postfix: new HarmonyMethod(typeof(StageHugsLibInit), nameof(PostLRI)));
             hInstance.Patch(AccessTools.Method(controllerType, "EnumerateChildMods"), postfix: new HarmonyMethod(typeof(StageHugsLibInit), nameof(PostEnumerateChildren)));
@@ -100,7 +100,7 @@ namespace BetterLoading.Compat.HugsLib
                 new HarmonyMethod(typeof(StageHugsLibInit), nameof(PostUpdateCheck))
             );
 
-            Log.Message("[BetterLoading:HugsLib Compat] Successfully blind-patched hugslib.");
+            Log.Message("[BetterLoading:HugsLib Compat] Successfully blind-patched HugsLib.");
         }
 
         public static void PostLRI()

--- a/Source/Compat/HugsLibCompat.cs
+++ b/Source/Compat/HugsLibCompat.cs
@@ -13,7 +13,7 @@ namespace BetterLoading.Compat
 
         public static void Load()
         {
-            Log.Message("[BetterLoading] HugsLib detected, Adding HugsLib support");
+            Log.Message("[BetterLoading] HugsLib detected, adding HugsLib support.");
             
             BetterLoadingApi.AddInitialLoadStage(new StageHugsLibInit(BetterLoadingMain.hInstance));
         }

--- a/Source/LoadingScreen.cs
+++ b/Source/LoadingScreen.cs
@@ -93,9 +93,9 @@ namespace BetterLoading
             return (T) ret;
         }
 
-        private void Awake()
+        public void Awake()
         {
-            Log.Message("BetterLoading :: Injected into main UI");
+            Log.Message("[BetterLoading] Injected into main UI.");
         }
 
         public void OnGUI()
@@ -104,7 +104,7 @@ namespace BetterLoading
 
             if (!LongEventHandler.AnyEventNowOrWaiting)
             {
-                Log.Message("Long event has finished, hiding loading screen.");
+                Log.Message("[BetterLoading] Long event has finished, hiding loading screen.");
                 shouldShow = false;
                 return;
             }
@@ -124,7 +124,7 @@ namespace BetterLoading
 
                 if (currentList == null)
                 {
-                    Log.Error("BetterLoading: Current Load Stage is not in a load list!");
+                    Log.Error("[BetterLoading] Current Load Stage is not in a load list!");
                     shouldShow = false;
                     return;
                 }
@@ -136,13 +136,13 @@ namespace BetterLoading
                 {
                     if (idx + 1 >= currentList.Count)
                     {
-                        Log.Message("BetterLoading: Finished processing load list, hiding.");
+                        Log.Message("[BetterLoading] Finished processing load list, hiding.");
                         shouldShow = false;
                         return;
                     }
 
                     //Move to next stage
-                    Log.Message("BetterLoading: Finished stage " + _currentStage.GetStageName() + " at " + DateTime.Now.ToLongTimeString());
+                    Log.Message($"[BetterLoading] Finished stage {_currentStage.GetStageName()} at {DateTime.Now.ToLongTimeString()}.");
                     try
                     {
                         _currentStage.BecomeInactive();
@@ -157,7 +157,7 @@ namespace BetterLoading
                     _currentStage = currentList[idx + 1];
                     try
                     {
-                        Log.Message("BetterLoading: Starting stage " + _currentStage.GetStageName());
+                        Log.Message($"[BetterLoading] Starting stage {_currentStage.GetStageName()}.");
                         _currentStage.BecomeActive();
                     }
                     catch (Exception e)
@@ -178,14 +178,14 @@ namespace BetterLoading
                 
                 if (maxProgress == 0)
                 {
-                    Log.Warning($"BetterLoading :: Stage {_currentStage.GetType().FullName} returned maxProgress = 0");
+                    Log.Warning($"[BetterLoading] The stage {_currentStage.GetType().FullName} returned maxProgress = 0.");
                     maxProgress = 1;
                 }
                 
                 if (currentProgress > maxProgress)
                 {
                     Log.Error(
-                        $"BetterLoading: Clamping! The stage of type {_currentStage.GetType().FullName} has returned currentProgress {currentProgress} > maxProgress {maxProgress}. Please report this!",
+                        $"[BetterLoading] Clamping! The stage of type {_currentStage.GetType().FullName} has returned currentProgress {currentProgress} > maxProgress {maxProgress}. Please report this!",
                         true);
                     currentProgress = maxProgress;
                 }

--- a/Source/Stage/InitialLoad/7StageRunPostLoadPreFinalizeCallbacks.cs
+++ b/Source/Stage/InitialLoad/7StageRunPostLoadPreFinalizeCallbacks.cs
@@ -140,7 +140,7 @@ namespace BetterLoading.Stage.InitialLoad
                     Thread.Sleep(2000); //Wait
                 }
                 
-                Log.Message($"[BetterLoading] Obtained synclock, assuming post-load actions are complete and starting static constructors");
+                Log.Message($"[BetterLoading] Obtained synclock, assuming post-load actions are complete and starting static constructors.");
 
                 runStaticCtors();
 

--- a/Source/Stage/InitialLoad/7StageRunPostLoadPreFinalizeCallbacks.cs
+++ b/Source/Stage/InitialLoad/7StageRunPostLoadPreFinalizeCallbacks.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using HarmonyLib;
-using UnityEngine;
 using Verse;
 
 namespace BetterLoading.Stage.InitialLoad
@@ -69,7 +67,6 @@ namespace BetterLoading.Stage.InitialLoad
 
         public static bool PreExecToExecWhenFinished(List<Action> ___toExecuteWhenFinished)
         {
-            // Debug.Log($"BL Debug StageRunPostLoadPreFinalizeCallbacks.PreExecToExecWhenFinished: hasBeenCalled={_hasBeenCalled}, finishedExecuting={_finishedExecuting}, toExecuteWhenFinished.Count={___toExecuteWhenFinished.Count}");
             if (_hasBeenCalled)
             {
                 //Don't let normal ExecuteToExecuteWhenFinished run while we're still executing, to avoid "Already executing" warnings
@@ -154,7 +151,6 @@ namespace BetterLoading.Stage.InitialLoad
 
         public static bool PreUpdateCurrentSynchronousEvent(/*object ___currentEvent*/)
         {
-            // Debug.Log($"BL Debug StageRunPostLoadPreFinalizeCallbacks.PreUpdateCurrentSynchronousEvent: hasBeenCalled={_hasBeenCalled}, finishedExecuting={_finishedExecuting}, action={Traverse.Create(___currentEvent).Field("eventAction").GetValue<Action>()?.Method?.FullDescription() ?? "null"}");
             if (_hasBeenCalled)
             {
                 //Don't let normal UpdateCurrentSynchronousEvent run while we're still executing, since some loading logic can rely on ExecuteToExecuteWhenFinished running synchronously

--- a/Source/Stage/InitialLoad/9StageRunPostFinalizeCallbacks.cs
+++ b/Source/Stage/InitialLoad/9StageRunPostFinalizeCallbacks.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using HarmonyLib;
-using UnityEngine;
 using Verse;
 
 namespace BetterLoading.Stage.InitialLoad
@@ -68,7 +67,6 @@ namespace BetterLoading.Stage.InitialLoad
         public static bool PreExecToExecWhenFinished(List<Action> ___toExecuteWhenFinished)
         {
             if (!ShouldInterceptNext) return true;
-            // Debug.Log($"BL Debug StageRunPostLoadPreFinalizeCallbacks.PreExecToExecWhenFinished: hasBeenCalled={_hasBeenCalled}, finishedExecuting={_finishedExecuting}, toExecuteWhenFinished.Count={___toExecuteWhenFinished.Count}");
             if (_hasBeenCalled)
             {
                 //Don't let normal ExecuteToExecuteWhenFinished run while we're still executing, to avoid "Already executing" warnings
@@ -134,7 +132,6 @@ namespace BetterLoading.Stage.InitialLoad
 
         public static bool PreUpdateCurrentSynchronousEvent(/*object ___currentEvent*/)
         {
-            // Debug.Log($"BL Debug StageRunPostLoadPreFinalizeCallbacks.PreUpdateCurrentSynchronousEvent: hasBeenCalled={_hasBeenCalled}, finishedExecuting={_finishedExecuting}, action={Traverse.Create(___currentEvent).Field("eventAction").GetValue<Action>()?.Method?.FullDescription() ?? "null"}");
             if (_hasBeenCalled)
             {
                 //Don't let normal UpdateCurrentSynchronousEvent run while we're still executing, since some loading logic can rely on ExecuteToExecuteWhenFinished running synchronously

--- a/Source/ToExecuteWhenFinishedHandler.cs
+++ b/Source/ToExecuteWhenFinishedHandler.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using HarmonyLib;
+using UnityEngine;
 using Verse;
 
 namespace BetterLoading
@@ -36,6 +38,7 @@ namespace BetterLoading
                             // _currentAction = action;
                             actionStartCallback(action);
 
+                            // Debug.Log($"BL Debug: ToExecuteWhenFinishedHandler toExecuteWhenFinished {index + 1}/{toExecuteWhenFinished.Count} action={action.Method.FullDescription()}");
                             action();
 
                             // _numTasksRun++;

--- a/Source/ToExecuteWhenFinishedHandler.cs
+++ b/Source/ToExecuteWhenFinishedHandler.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using HarmonyLib;
-using UnityEngine;
 using Verse;
 
 namespace BetterLoading
@@ -38,7 +36,6 @@ namespace BetterLoading
                             // _currentAction = action;
                             actionStartCallback(action);
 
-                            // Debug.Log($"BL Debug: ToExecuteWhenFinishedHandler toExecuteWhenFinished {index + 1}/{toExecuteWhenFinished.Count} action={action.Method.FullDescription()}");
                             action();
 
                             // _numTasksRun++;

--- a/Source/ToExecuteWhenFinishedHandler.cs
+++ b/Source/ToExecuteWhenFinishedHandler.cs
@@ -18,7 +18,7 @@ namespace BetterLoading
             lastEnd = DateTime.Now.Ticks;
             if (LongEventHandlerMirror.CurrentlyExecutingToExecuteWhenFinished)
             {
-                Log.Warning("BL: Already executing.");
+                Log.Warning("[BetterLoading] ToExecuteWhenFinishedHandler already executing.");
             }
             else
             {
@@ -72,7 +72,7 @@ namespace BetterLoading
                 }
                 catch (Exception e)
                 {
-                    Log.Error("BL: Exception finishing up toExecuteWhenFinished! " + e);
+                    Log.Error("[BetterLoading] Exception finishing up toExecuteWhenFinished! " + e);
                 }
                 finally
                 {


### PR DESCRIPTION
- Address some race conditions and fix warnings caused by synchronous events or new ExecuteWhenFinished actions running during an already running ExecuteToExecuteWhenFinished
  - This caused an error when running a Steam build of RimWorld without a Steam connection, since it tried to create a dialog box and its accompanying sound effect, when the SubSoundDef.resolvedGrains was not resolved in an ExecuteWhenFinished action yet
- More consistent log message formatting
- Add .vs to .gitignore
- Add sln for Visual Studio