### PR TITLE
Stop copying `0harmony.dll` into the release

### DIFF
--- a/Source/BetterLoading.csproj
+++ b/Source/BetterLoading.csproj
@@ -44,7 +44,11 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Lib.Harmony" Version="2.1.0" />
+    <PackageReference Include="Lib.Harmony" Version="2.2.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>compile; build</IncludeAssets>
+      <ExcludedAssets>runtime</ExcludedAssets>
+    </PackageReference>
     <PackageReference Include="Samboy063.Tomlet" Version="3.1.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This marks the nuget harmony library as private, for build only, so that
`0harmony.dll` is no longer copied into the build target.  Since the mod
uses the shipped-from-workshop harmony mod, this is how things should
be.

I also bumped the harmony version to 2.2.1 to match the current steam
harmony mod.  Not strictly necessary, but since 2.2.1 brings back
`CodeMatcher`, definitely nice to have for that vastly smoother
Transpiler patch writing experience.