### PR TITLE
Implement using vanilla UIMenuBackgroundManager

### DIFF
--- a/Source/BetterLoadingMain.cs
+++ b/Source/BetterLoadingMain.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using BetterLoading.Compat;
 using BetterLoading.Stage.SaveLoad;
 using HarmonyLib;
@@ -116,14 +115,7 @@ namespace BetterLoading
 
         private static void InitLoadingScreenBackground()
         {
-            try
-            {
-                LoadingScreen!.Background = typeof(UI_BackgroundMain).GetField("BGPlanet", BindingFlags.NonPublic | BindingFlags.Static)!.GetValue(null) as Texture2D;
-            }
-            catch (Exception e)
-            {
-                Log.Warning($"Failed to find or set background texture:\n{e}");
-            }
+            LoadingScreen!.PickBackground();
         }
 
         private void CreateTimingReport()

--- a/Source/LoadingScreen.cs
+++ b/Source/LoadingScreen.cs
@@ -3,9 +3,11 @@ using BetterLoading.Stage.InitialLoad;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using BetterLoading.Stage.SaveLoad;
 using UnityEngine;
 using Verse;
+using RimWorld;
 
 namespace BetterLoading
 {
@@ -118,6 +120,18 @@ namespace BetterLoading
         public void Awake()
         {
             Log.Message("[BetterLoading] Injected into main UI.");
+        }
+
+        public void PickBackground()
+        {
+            try
+            {
+                Background = ((UI_BackgroundMain)UIMenuBackgroundManager.background).overrideBGImage ?? (typeof(UI_BackgroundMain).GetField("BGPlanet", BindingFlags.NonPublic | BindingFlags.Static)!.GetValue(null) as Texture2D);
+            }
+            catch (Exception e)
+            {
+                Log.Warning($"Failed to find or set background texture:\n{e}");
+            }
         }
 
         private void DrawBackground()

--- a/Source/Stage/InitialLoad/6StageResolveDefDatabases.cs
+++ b/Source/Stage/InitialLoad/6StageResolveDefDatabases.cs
@@ -54,6 +54,10 @@ namespace BetterLoading.Stage.InitialLoad
             base.BecomeInactive();
             Log.Message("[BetterLoading] Tips should now be available. Showing...");
             LoadingScreenTipManager.GameTipDatabaseHasLoaded = true;
+            if (!Prefs.RandomBackgroundImage)
+            {
+                BetterLoadingMain.LoadingScreen!.Background = Prefs.BackgroundImageExpansion.BackgroundImage;
+            }
         }
 
         public override void DoPatching(Harmony instance)

--- a/Source/Stage/InitialLoad/7StageRunPostLoadPreFinalizeCallbacks.cs
+++ b/Source/Stage/InitialLoad/7StageRunPostLoadPreFinalizeCallbacks.cs
@@ -81,6 +81,11 @@ namespace BetterLoading.Stage.InitialLoad
             inst = LoadingScreen.GetStageInstance<StageRunPostLoadPreFinalizeCallbacks>();
         }
 
+        public override void BecomeInactive()
+        {
+            BetterLoadingMain.LoadingScreen!.PickBackground();
+        }
+
         public override void DoPatching(Harmony instance)
         {
             instance.Patch(AccessTools.Method(typeof(LongEventHandler), "ExecuteToExecuteWhenFinished"), new(typeof(StageRunPostLoadPreFinalizeCallbacks), nameof(PreExecToExecWhenFinished)));


### PR DESCRIPTION
This change made the mod respect the vanilla "Menu background" setting instead of always using Core background.

By reading the vanilla menu background, the change ensures that the background is the same when transitioning from the vanilla loading screen to the mod loading screen.

During a startup, if the chosen background option is not "random", the background loads as soon as all defs are resolved (after stage 7); otherwise, it loads after `RimWorld.MainMenuDrawer.Init` is called for the first time (after stage 8).
![screenshot](https://github.com/SamboyCoding/RimworldBetterLoading/assets/9017157/5c42a780-0686-4689-9253-d6567f12db78)
